### PR TITLE
New Feature: Ability to print based on Package Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ Usage
   - Optional 
   - ***Example:*** `./DoSPDX.py --documentComment "Scanned as part of the Yocto build process."`
 - `--spdxDocId [SPDX Doc Id]` Used to generate the spdx document object from the MySql Database.
-  - Conditionally optional, Required if `-s` or `--scan` is not used.
+  - Conditionally optional, Required if `-s`, `--scan`, r --spdxDocName is not used.
   - ***Example:*** `./DoSPDX.py --spdxDocId 37` 
+- `--spdxDocName [SPDX Upload Package Name]` Used to generate the spdx document object from the MySql Database based on original package name.
+  - Conditionally optional, Required if `-s`, `--scan`, or --spdxDocId is not used.
+  - ***Example:*** `./DoSPDX.py --spdxDocName archive.tar.bz2` 
 - `--creator [Creator]` Specifies who is creating the SPDX document.
   - Optional
   - ***Example:*** `./DoSPDX.py --creator "Zachary McFarland"` 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ Usage
   - Optional 
   - ***Example:*** `./DoSPDX.py --documentComment "Scanned as part of the Yocto build process."`
 - `--spdxDocId [SPDX Doc Id]` Used to generate the spdx document object from the MySql Database.
-  - Conditionally optional, Required if `-s`, `--scan`, r --spdxDocName is not used.
+  - Conditionally optional, Required if `-s`, `--scan`, or `--spdxDocName` is not used.
   - ***Example:*** `./DoSPDX.py --spdxDocId 37` 
 - `--spdxDocName [SPDX Upload Package Name]` Used to generate the spdx document object from the MySql Database based on original package name.
-  - Conditionally optional, Required if `-s`, `--scan`, or --spdxDocId is not used.
+  - Conditionally optional, Required if `-s`, `--scan`, or `--spdxDocId` is not used.
   - ***Example:*** `./DoSPDX.py --spdxDocName archive.tar.bz2` 
 - `--creator [Creator]` Specifies who is creating the SPDX document.
   - Optional

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Usage
 - `--spdxDocId [SPDX Doc Id]` Used to generate the spdx document object from the MySql Database.
   - Conditionally optional, Required if `-s`, `--scan`, or `--spdxDocName` is not used.
   - ***Example:*** `./DoSPDX.py --spdxDocId 37` 
-- `--spdxDocName [SPDX Upload Package Name]` Used to generate the spdx document object from the MySql Database based on original package name.
+- `--spdxDocName [SPDX Upload Package Name]` Used to generate the latest spdx document object from the MySql Database based on original package name.
   - Conditionally optional, Required if `-s`, `--scan`, or `--spdxDocId` is not used.
   - ***Example:*** `./DoSPDX.py --spdxDocName archive.tar.bz2` 
 - `--creator [Creator]` Specifies who is creating the SPDX document.

--- a/src/DoSPDX.py
+++ b/src/DoSPDX.py
@@ -47,6 +47,7 @@ def main(argv):
                                             "scanOption=",
                                             "print=",
                                             "spdxDocId=",
+                                            "spdxDocName=",
                                             "scan"])
 
     documentComment = ""
@@ -66,6 +67,7 @@ def main(argv):
     output = ""
     scan = False
     spdxDocId = None
+    spdxDocName = None
 
     for opt, arg in opts:
         if opt == '-h':
@@ -102,6 +104,8 @@ def main(argv):
             scan = True
         elif opt == '--spdxDocId':
             spdxDocId = arg
+        elif opt == '--spdxDocName':
+            spdxDocName = arg
 
     '''Validate package path'''
     if scan and (packagePath == None or not os.path.isfile(packagePath)):
@@ -126,6 +130,9 @@ def main(argv):
     result = True;
     if spdxDocId != None:
         result = spdxDoc.getSPDX(spdxDocId)
+
+    if spdxDocName != None:
+        result = spdxDoc.getSPDXPackage(spdxDocName)
 
     if result == False:
         sys.exit()

--- a/src/spdx.py
+++ b/src/spdx.py
@@ -304,7 +304,7 @@ class SPDX:
                 tempReviewerInfo.getReviwerInfo(dbCursorfetchone()[0], dbCursor)
                 self.reviewerInfo.append(tempReviewerInfo)
 
-    def generateSPDXDoc(self,scanOption):
+    def generateSPDXDoc(self):
         '''Generates the entire structure by querying and scanning the files.'''
         extractTo = tempfile.mkdtemp()
         ninka_out = tempfile.NamedTemporaryFile()
@@ -360,7 +360,7 @@ class SPDX:
                 for fileName in archive.namelist():
                     if os.path.isfile(os.path.join(extractTo, fileName)):
                         tempFileInfo = fileInfo.fileInfo(os.path.join(extractTo, fileName), os.path.join(path, fileName))
-                        tempFileInfo.populateFileInfo(self.scanOption)
+                        tempFileInfo.populateFileInfo()
                         tempLicenseInfo = licensingInfo.licensingInfo(
                                                         "LicenseRef-" + str(licenseCounter),
                                                         tempFileInfo.extractedText,

--- a/src/spdx.py
+++ b/src/spdx.py
@@ -242,7 +242,7 @@ class SPDX:
         return output
 
     def getSPDXPackage(self, spdx_package):
-        '''Retrieves the spdx_package based on input package id'''
+        '''Retrieves the spdx_package based on input package name'''
 
         with MySQLdb.connect(    host=settings.database_host,
                                 user=settings.database_user,


### PR DESCRIPTION
This is a request for new feature to be added: The ability to print the latest SPDX document based on the original upload package name. This would allow users to retrieve the latest scanned package for a particular package without knowing the ID. The new parameter that has been added is  `--spdxDocName`

   - ***Example:*** `./DoSPDX.py --print TAG --spdxDocName archive.tar.bz2`


If duplicate packages with the same package name exist, then the latest scanned package will be returned.